### PR TITLE
Add npm test script for docs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "npm run generate:meta && docusaurus build",
     "start": "docusaurus serve --dir build --host 0.0.0.0 --port ${PORT:-3000}",
     "serve": "npm run start",
+    "test": "npm run build",
     "generate:meta": "node scripts/generateMeta.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add an npm `test` script that runs the docs build so automated test runs succeed

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa6648fec8329bfd42e5dc7a10f40)