### PR TITLE
Fix Railway deployment for BlackRoad docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,16 +6,11 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -H 0.0.0.0 -p ${PORT:-8080}",
+    "start": "next start -H 0.0.0.0 -p 8080",
     "lint": "next lint"
   },
   "engines": {
-    "node": ">=20",
-    "dev": "docusaurus start",
-    "build": "npm run generate:meta && docusaurus build",
-    "start": "node scripts/serve.js",
-    "serve": "npm run start",
-    "generate:meta": "node scripts/generateMeta.js"
+    "node": ">=20"
   },
   "dependencies": {
     "next": "14.2.4",


### PR DESCRIPTION
- Fix package.json: remove malformed engines section with Docusaurus scripts
- Set PORT to 8080 for Railway deployment
- Health endpoint already exists at /api/health