### PR TITLE
Respect PORT env in start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -H 0.0.0.0 -p 8080",
+    "start": "next start -H 0.0.0.0 -p ${PORT:-8080}",
     "lint": "next lint"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- update Next.js start script to honor PORT environment variable while defaulting to 8080

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211250b18083298f6076ec54a3b2ba)