### PR TITLE
Update docs start script for Railway compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Visit http://localhost:3000.
 npm run build
 npm start
 ```
-The start command serves the production build. By default, it uses port 3000, but you can set the `PORT` environment variable to use a different port (e.g., `PORT=8080 npm start`).
+The start command serves the production build. It binds to `0.0.0.0` and uses the `PORT` environment variable (default `8080`).
 
 ## Key routes
 - `/` – docs homepage

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,12 +22,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "build": "npm run generate:meta && docusaurus build",
-        "dev": "docusaurus start",
-        "generate:meta": "node scripts/generateMeta.js",
-        "node": ">=20",
-        "serve": "npm run start",
-        "start": "node scripts/serve.js"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -H 0.0.0.0 -p 8080",
+    "start": "PORT=${PORT:-8080} HOST=0.0.0.0 next start -H $HOST -p $PORT",
     "lint": "next lint"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- update the docs start script to bind to 0.0.0.0 and respect the PORT environment variable with an 8080 default
- document the revised start behavior in the README for Railway deployments

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69215760645c8329a3392dcf775b52d9)